### PR TITLE
remove everything related to MPI_Fint

### DIFF
--- a/mpi.h
+++ b/mpi.h
@@ -37,14 +37,6 @@ typedef MPI_ABI_Offset MPI_Offset;
 typedef MPI_ABI_Count MPI_Count;
 #undef  MPI_ABI_Count
 
-/* MPI_Fint must match the Fortran default INTEGER kind. */
-/* It is often equivalent to C int but most compilers support wider options. */
-#if !defined(MPI_ABI_Fint)
-#define MPI_ABI_Fint int
-#endif
-typedef MPI_ABI_Fint MPI_Fint;
-#undef  MPI_ABI_Fint
-
 typedef struct {
     int MPI_SOURCE;
     int MPI_TAG;
@@ -186,14 +178,6 @@ enum {
     MPI_F_TAG                          = 1,
     MPI_F_ERROR                        = 2
 };
-
-/* Fortran 2008 Status Type */
-typedef struct {
-  MPI_Fint MPI_SOURCE;
-  MPI_Fint MPI_TAG;
-  MPI_Fint MPI_ERROR;
-  MPI_Fint MPI_internal[5];
-} MPI_F08_status;
 
 /* Error Classes */
 enum {
@@ -1163,35 +1147,6 @@ MPI_Aint MPI_Aint_diff(MPI_Aint addr1, MPI_Aint addr2);
 double MPI_Wtick(void);
 double MPI_Wtime(void);
 
-int MPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status);
-int MPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status);
-int MPI_Status_c2f08(const MPI_Status *c_status, MPI_F08_status *f08_status);
-int MPI_Status_f082c(const MPI_F08_status *f08_status, MPI_Status *c_status);
-int MPI_Status_f2f08(const MPI_Fint *f_status, MPI_F08_status *f08_status);
-int MPI_Status_f082f(const MPI_F08_status *f08_status, MPI_Fint *f_status);
-MPI_Fint MPI_Comm_c2f(MPI_Comm comm);
-MPI_Comm MPI_Comm_f2c(MPI_Fint comm);
-MPI_Fint MPI_Errhandler_c2f(MPI_Errhandler errhandler);
-MPI_Errhandler MPI_Errhandler_f2c(MPI_Fint errhandler);
-MPI_Fint MPI_Type_c2f(MPI_Datatype datatype);
-MPI_Datatype MPI_Type_f2c(MPI_Fint datatype);
-MPI_Fint MPI_File_c2f(MPI_File file);
-MPI_File MPI_File_f2c(MPI_Fint file);
-MPI_Fint MPI_Group_c2f(MPI_Group group);
-MPI_Group MPI_Group_f2c(MPI_Fint group);
-MPI_Fint MPI_Info_c2f(MPI_Info info);
-MPI_Info MPI_Info_f2c(MPI_Fint info);
-MPI_Fint MPI_Message_c2f(MPI_Message message);
-MPI_Message MPI_Message_f2c(MPI_Fint message);
-MPI_Fint MPI_Op_c2f(MPI_Op op);
-MPI_Op MPI_Op_f2c(MPI_Fint op);
-MPI_Fint MPI_Request_c2f(MPI_Request request);
-MPI_Request MPI_Request_f2c(MPI_Fint request);
-MPI_Fint MPI_Session_c2f(MPI_Session session);
-MPI_Session MPI_Session_f2c(MPI_Fint session);
-MPI_Fint MPI_Win_c2f(MPI_Win win);
-MPI_Win MPI_Win_f2c(MPI_Fint win);
-
 /* MPI_T functions */
 int MPI_T_category_changed(int *update_number);
 int MPI_T_category_get_categories(int cat_index, int len, int indices[]);
@@ -1832,35 +1787,6 @@ MPI_Aint PMPI_Aint_add(MPI_Aint base, MPI_Aint disp);
 MPI_Aint PMPI_Aint_diff(MPI_Aint addr1, MPI_Aint addr2);
 double PMPI_Wtick(void);
 double PMPI_Wtime(void);
-
-int PMPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status);
-int PMPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status);
-int PMPI_Status_c2f08(const MPI_Status *c_status, MPI_F08_status *f08_status);
-int PMPI_Status_f082c(const MPI_F08_status *f08_status, MPI_Status *c_status);
-int PMPI_Status_f2f08(const MPI_Fint *f_status, MPI_F08_status *f08_status);
-int PMPI_Status_f082f(const MPI_F08_status *f08_status, MPI_Fint *f_status);
-MPI_Fint PMPI_Comm_c2f(MPI_Comm comm);
-MPI_Comm PMPI_Comm_f2c(MPI_Fint comm);
-MPI_Fint PMPI_Errhandler_c2f(MPI_Errhandler errhandler);
-MPI_Errhandler PMPI_Errhandler_f2c(MPI_Fint errhandler);
-MPI_Fint PMPI_Type_c2f(MPI_Datatype datatype);
-MPI_Datatype PMPI_Type_f2c(MPI_Fint datatype);
-MPI_Fint PMPI_File_c2f(MPI_File file);
-MPI_File PMPI_File_f2c(MPI_Fint file);
-MPI_Fint PMPI_Group_c2f(MPI_Group group);
-MPI_Group PMPI_Group_f2c(MPI_Fint group);
-MPI_Fint PMPI_Info_c2f(MPI_Info info);
-MPI_Info PMPI_Info_f2c(MPI_Fint info);
-MPI_Fint PMPI_Message_c2f(MPI_Message message);
-MPI_Message PMPI_Message_f2c(MPI_Fint message);
-MPI_Fint PMPI_Op_c2f(MPI_Op op);
-MPI_Op PMPI_Op_f2c(MPI_Fint op);
-MPI_Fint PMPI_Request_c2f(MPI_Request request);
-MPI_Request PMPI_Request_f2c(MPI_Fint request);
-MPI_Fint PMPI_Session_c2f(MPI_Session session);
-MPI_Session PMPI_Session_f2c(MPI_Fint session);
-MPI_Fint PMPI_Win_c2f(MPI_Win win);
-MPI_Win PMPI_Win_f2c(MPI_Fint win);
 
 /* PMPI_T functions */
 int PMPI_T_category_changed(int *update_number);

--- a/mpistubs.c
+++ b/mpistubs.c
@@ -589,35 +589,6 @@ MPI_Aint MPI_Aint_diff(MPI_Aint addr1, MPI_Aint addr2) { abort(); return 0; }
 double MPI_Wtick(void) { abort(); return 0; }
 double MPI_Wtime(void) { abort(); return 0; }
 
-int MPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status) { abort(); return 0; }
-int MPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status) { abort(); return 0; }
-int MPI_Status_c2f08(const MPI_Status *c_status, MPI_F08_status *f08_status) { abort(); return 0; }
-int MPI_Status_f082c(const MPI_F08_status *f08_status, MPI_Status *c_status) { abort(); return 0; }
-int MPI_Status_f2f08(const MPI_Fint *f_status, MPI_F08_status *f08_status) { abort(); return 0; }
-int MPI_Status_f082f(const MPI_F08_status *f08_status, MPI_Fint *f_status) { abort(); return 0; }
-MPI_Fint MPI_Comm_c2f(MPI_Comm comm) { abort(); return 0; }
-MPI_Comm MPI_Comm_f2c(MPI_Fint comm) { abort(); return 0; }
-MPI_Fint MPI_Errhandler_c2f(MPI_Errhandler errhandler) { abort(); return 0; }
-MPI_Errhandler MPI_Errhandler_f2c(MPI_Fint errhandler) { abort(); return 0; }
-MPI_Fint MPI_Type_c2f(MPI_Datatype datatype) { abort(); return 0; }
-MPI_Datatype MPI_Type_f2c(MPI_Fint datatype) { abort(); return 0; }
-MPI_Fint MPI_File_c2f(MPI_File file) { abort(); return 0; }
-MPI_File MPI_File_f2c(MPI_Fint file) { abort(); return 0; }
-MPI_Fint MPI_Group_c2f(MPI_Group group) { abort(); return 0; }
-MPI_Group MPI_Group_f2c(MPI_Fint group) { abort(); return 0; }
-MPI_Fint MPI_Info_c2f(MPI_Info info) { abort(); return 0; }
-MPI_Info MPI_Info_f2c(MPI_Fint info) { abort(); return 0; }
-MPI_Fint MPI_Message_c2f(MPI_Message message) { abort(); return 0; }
-MPI_Message MPI_Message_f2c(MPI_Fint message) { abort(); return 0; }
-MPI_Fint MPI_Op_c2f(MPI_Op op) { abort(); return 0; }
-MPI_Op MPI_Op_f2c(MPI_Fint op) { abort(); return 0; }
-MPI_Fint MPI_Request_c2f(MPI_Request request) { abort(); return 0; }
-MPI_Request MPI_Request_f2c(MPI_Fint request) { abort(); return 0; }
-MPI_Fint MPI_Session_c2f(MPI_Session session) { abort(); return 0; }
-MPI_Session MPI_Session_f2c(MPI_Fint session) { abort(); return 0; }
-MPI_Fint MPI_Win_c2f(MPI_Win win) { abort(); return 0; }
-MPI_Win MPI_Win_f2c(MPI_Fint win) { abort(); return 0; }
-
 /* MPI_T functions */
 int MPI_T_category_changed(int *update_number) { abort(); return 0; }
 int MPI_T_category_get_categories(int cat_index, int len, int indices[]) { abort(); return 0; }
@@ -1258,35 +1229,6 @@ MPI_Aint PMPI_Aint_add(MPI_Aint base, MPI_Aint disp) { abort(); return 0; }
 MPI_Aint PMPI_Aint_diff(MPI_Aint addr1, MPI_Aint addr2) { abort(); return 0; }
 double PMPI_Wtick(void) { abort(); return 0; }
 double PMPI_Wtime(void) { abort(); return 0; }
-
-int PMPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status) { abort(); return 0; }
-int PMPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status) { abort(); return 0; }
-int PMPI_Status_c2f08(const MPI_Status *c_status, MPI_F08_status *f08_status) { abort(); return 0; }
-int PMPI_Status_f082c(const MPI_F08_status *f08_status, MPI_Status *c_status) { abort(); return 0; }
-int PMPI_Status_f2f08(const MPI_Fint *f_status, MPI_F08_status *f08_status) { abort(); return 0; }
-int PMPI_Status_f082f(const MPI_F08_status *f08_status, MPI_Fint *f_status) { abort(); return 0; }
-MPI_Fint PMPI_Comm_c2f(MPI_Comm comm) { abort(); return 0; }
-MPI_Comm PMPI_Comm_f2c(MPI_Fint comm) { abort(); return 0; }
-MPI_Fint PMPI_Errhandler_c2f(MPI_Errhandler errhandler) { abort(); return 0; }
-MPI_Errhandler PMPI_Errhandler_f2c(MPI_Fint errhandler) { abort(); return 0; }
-MPI_Fint PMPI_Type_c2f(MPI_Datatype datatype) { abort(); return 0; }
-MPI_Datatype PMPI_Type_f2c(MPI_Fint datatype) { abort(); return 0; }
-MPI_Fint PMPI_File_c2f(MPI_File file) { abort(); return 0; }
-MPI_File PMPI_File_f2c(MPI_Fint file) { abort(); return 0; }
-MPI_Fint PMPI_Group_c2f(MPI_Group group) { abort(); return 0; }
-MPI_Group PMPI_Group_f2c(MPI_Fint group) { abort(); return 0; }
-MPI_Fint PMPI_Info_c2f(MPI_Info info) { abort(); return 0; }
-MPI_Info PMPI_Info_f2c(MPI_Fint info) { abort(); return 0; }
-MPI_Fint PMPI_Message_c2f(MPI_Message message) { abort(); return 0; }
-MPI_Message PMPI_Message_f2c(MPI_Fint message) { abort(); return 0; }
-MPI_Fint PMPI_Op_c2f(MPI_Op op) { abort(); return 0; }
-MPI_Op PMPI_Op_f2c(MPI_Fint op) { abort(); return 0; }
-MPI_Fint PMPI_Request_c2f(MPI_Request request) { abort(); return 0; }
-MPI_Request PMPI_Request_f2c(MPI_Fint request) { abort(); return 0; }
-MPI_Fint PMPI_Session_c2f(MPI_Session session) { abort(); return 0; }
-MPI_Session PMPI_Session_f2c(MPI_Fint session) { abort(); return 0; }
-MPI_Fint PMPI_Win_c2f(MPI_Win win) { abort(); return 0; }
-MPI_Win PMPI_Win_f2c(MPI_Fint win) { abort(); return 0; }
 
 /* PMPI_T functions */
 int PMPI_T_category_changed(int *update_number) { abort(); return 0; }


### PR DESCRIPTION
MPI 5.0 says:
> As a result, the functions defined in Section 19.3.4 and Section 19.3.5 are not part of this ABI.

I need to do a short reading to add `MPI_F08_Status` to the list.

Users no longer need an `MPI_F08_Status` typedef because the status ABI is no longer opaque and users can do the status conversion manually once they know the Fortran integer size, which they can determine already.  I am going to read this change in the next few minutes.

Resolves https://github.com/mpi-forum/mpi-abi-stubs/issues/46