### PR TITLE
add upper bound to cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.5.0...4.1.0)
 project(mpi-abi-stubs VERSION 5.0 LANGUAGES C)
 
 option(BUILD_SHARED_LIBS "Build libraries as SHARED" TRUE)


### PR DESCRIPTION
avoids warnings and future errors with old lower bound:

> CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

>  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.