### PR TITLE
Support alternate (user-defined) implementations of `mpistubs.c`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,11 @@ project(mpi-abi-stubs VERSION 5.0 LANGUAGES C)
 
 option(BUILD_SHARED_LIBS "Build libraries as SHARED" TRUE)
 
-add_library(mpi_abi mpistubs.c)
+set(MPI_SOURCE mpistubs.c CACHE STRING "MPI implementation source")
+add_library(mpi_abi "${MPI_SOURCE}")
 set_target_properties(mpi_abi PROPERTIES VERSION 1)
 set_target_properties(mpi_abi PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
+set_target_properties(mpi_abi PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 include(GNUInstallDirs)
 install(FILES mpi.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ default: install
 
 SCRIPTS  = mpicc mpicxx
 SOURCE_H = mpi.h
-SOURCE_C = mpistubs.c
+MPI_SOURCE ?= mpistubs.c
+SOURCE_C = $(MPI_SOURCE)
 LIBNAME  = mpi_abi
 VERSION  = 1
 
@@ -43,11 +44,13 @@ ifndef CFLAGS
     CFLAGS += -pedantic -Wall -Wextra
     CFLAGS += -Wno-unused-parameter
     CFLAGS += -Wno-unreachable-code-return
+    CFLAGS += -fPIC
   else
     CFLAGS  = $(if $(cc_std),-std=$(cc_std))
     CFLAGS += -pedantic -Weverything
     CFLAGS += -Wno-unused-parameter
     CFLAGS += -Wno-unreachable-code-return
+    CFLAGS += -fPIC
   endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -46,9 +46,12 @@ install_headers(
   'mpi.h'
 )
 
+mpi_source = get_option('mpi_source')
+
 library(
   'mpi_abi',
-  'mpistubs.c',
+  mpi_source,
   version: '1',
   install : true,
+  pic : true,
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+  'mpi_source',
+  type : 'string',
+  value : 'mpistubs.c',
+  description : 'Source file implementing the MPI ABI'
+)


### PR DESCRIPTION
This follows from the discussion in https://github.com/mpi-forum/mpi-abi-stubs/issues/78 and provides a way for the user to define their own version of `mpistubs.c` while still leveraging the infrastructure (and testing) provided by the existing library.

The PIC was needed to avoid errors like
```
/cvmfs/software.eessi.io/versions/2025.06/compat/linux/aarch64/usr/bin/ld: /tmp/ccTqtYmo.o: relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol stderr@@GLIBC_2.17' which may bind externally can not be used when making a shared object; recompile with -fPIC
```
when using my own trampoline implementation (if you know of another solution, I can change it)