### PR TITLE
Install compiler wrapper symlinks with _abi suffix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,29 +49,28 @@ else()
   set(rpath $libdir)
 endif()
 
+set(mpicc.CC CC)
+set(mpicc.cc cc)
+set(mpicc.op cc)
+set(mpicxx.CC CXX)
+set(mpicxx.cc c++)
+set(mpicxx.op cxx)
 set(permissions
   OWNER_READ OWNER_WRITE OWNER_EXECUTE
   GROUP_READ GROUP_EXECUTE
   WORLD_READ WORLD_EXECUTE
 )
-set(CC CC)
-set(cc cc)
-set(op cc)
-configure_file(mpicc.in mpicc @ONLY)
-install(
-  FILES ${CMAKE_BINARY_DIR}/mpicc
-  PERMISSIONS ${permissions}
-  DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
-set(CC CXX)
-set(cc c++)
-set(op cxx)
-configure_file(mpicc.in mpicxx @ONLY)
-install(
-  FILES ${CMAKE_BINARY_DIR}/mpicxx
-  PERMISSIONS ${permissions}
-  DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+foreach(script mpicc mpicxx)
+  set(CC ${${script}.CC})
+  set(cc ${${script}.cc})
+  set(op ${${script}.op})
+  configure_file(mpicc.in ${script} @ONLY)
+  install(
+    FILES ${CMAKE_BINARY_DIR}/${script}
+    PERMISSIONS ${permissions}
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+  )
+endforeach()
 
 install(FILES ${SOURCE_H} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,28 @@ foreach(script mpicc mpicxx)
     PERMISSIONS ${permissions}
     DESTINATION ${CMAKE_INSTALL_BINDIR}
   )
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14.0)
+    file(CREATE_LINK
+      ${script} ${CMAKE_BINARY_DIR}/${script}_abi
+      SYMBOLIC COPY_ON_ERROR
+    )
+  else()
+    set(create_symlink create_symlink)
+    if(WIN32 AND CMAKE_VERSION VERSION_LESS 3.13.0)
+      set(create_symlink copy)
+    endif()
+    add_custom_target(${script}_abi ALL VERBATIM
+      DEPENDS ${CMAKE_BINARY_DIR}/${script}
+      BYPRODUCTS ${CMAKE_BINARY_DIR}/${script}_abi
+      COMMAND ${CMAKE_COMMAND} -E ${create_symlink}
+      ${script} ${CMAKE_BINARY_DIR}/${script}_abi
+    )
+  endif()
+  install(
+    FILES ${CMAKE_BINARY_DIR}/${script}_abi
+    PERMISSIONS ${permissions}
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+  )
 endforeach()
 
 install(FILES ${SOURCE_H} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
@@ -121,7 +143,7 @@ if(WIN32 AND SKBUILD)
 venvdir=$(CDPATH='' cd -- "$(dirname -- "$0")"/.. && pwd)
 exec "$venvdir/Library/bin/@script@" "$@"
 ]])
-  foreach(script mpicc mpicxx)
+  foreach(script mpicc mpicxx mpicc_abi mpicxx_abi)
     set(wrapper ${CMAKE_BINARY_DIR}/${script}-wrapper)
     configure_file(${template} ${wrapper} @ONLY)
     install(

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ DESTLIBDIR = $(DESTDIR)$(PREFIX)/$(LIBDIR)
 install: install-scripts install-headers install-library
 install-scripts: $(foreach f,$(SCRIPTS),$(BUILD)/$(f)) | $(DESTBINDIR)/.
 	install -c -m 755 $^ $(DESTBINDIR)
+	cd $(DESTBINDIR) && $(foreach f,$(^F),$(LN_S) $(f) $(f)_abi &&) true;
 install-headers: $(SOURCE_H) | $(DESTINCDIR)/.
 	install -c -m 644 $^ $(DESTINCDIR)
 install-library: $(BUILD)/$(LIBFILE) | $(DESTLIBDIR)/.
@@ -132,9 +133,10 @@ install-library: $(BUILD)/$(LIBFILE) | $(DESTLIBDIR)/.
 .PHONY: uninstall uninstall-scripts uninstall-headers uninstall-library
 uninstall: uninstall-scripts uninstall-headers uninstall-library
 uninstall-scripts:
-	-$(RM) -r $(foreach f,$(SCRIPTS),$(DESTBINDIR)/$(f))
+	-$(RM) $(foreach f,$(SCRIPTS),$(DESTBINDIR)/$(f))
+	-$(RM) $(foreach f,$(SCRIPTS),$(DESTBINDIR)/$(f)_abi)
 uninstall-headers:
-	-$(RM) -r $(foreach f,$(SOURCE_H),$(DESTINCDIR)/$(f))
+	-$(RM) $(foreach f,$(SOURCE_H),$(DESTINCDIR)/$(f))
 uninstall-library:
 	-$(RM) $(DESTLIBDIR)/$(LIBFILE)
 	-$(RM) $(DESTLIBDIR)/$(LIBLINK)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ mpi-abi-stubs/
 ├── mpi.h           # MPI ABI header file
 ├── mpilib.c        # Library stubs implementation
 ├── mpilib.def      # Visual Studio module-definition
-├── mpicc.in        # Template for mpicc/mpicxx wrappers
+├── mpicc.in        # Template for compiler wrappers
 ├── Makefile        # GNU Make build system
 ├── CMakeLists.txt  # CMake build system
 ├── meson.build     # Meson build system

--- a/check.sh
+++ b/check.sh
@@ -56,6 +56,9 @@ ln -s helloworld.c helloworld.cxx
 
 command -v mpicc
 command -v mpicxx
+command -v mpicc_abi
+command -v mpicxx_abi
+
 echo "$(mpicc -show-incdir)/mpi.h":
 grep -E 'MPI_(SUB)?VERSION' "$(mpicc -show-incdir)/mpi.h"
 grep -E 'MPI_ABI_(SUB)?VERSION' "$(mpicc -show-incdir)/mpi.h"

--- a/meson.build
+++ b/meson.build
@@ -71,6 +71,11 @@ foreach script: ['mpicc', 'mpicxx']
     install_dir: get_option('bindir'),
     install_mode: 'rwxr-xr-x',
   )
+  install_symlink(
+    script + '_abi',
+    pointing_to: script,
+    install_dir: get_option('bindir'),
+  )
 endforeach
 
 install_headers(


### PR DESCRIPTION
MPICH and Open MPI provide `mpicc_abi`/`mpicxx_abi` to compile and link against their MPI ABI implementation. Add these suffixed wrappers here too. This way, third party build setups can switch the MPI ABI backend with minimal adjustments (e.g. maybe just `$PATH`).